### PR TITLE
Option to disable STUN probing

### DIFF
--- a/Limelight/Network/DiscoveryManager.m
+++ b/Limelight/Network/DiscoveryManager.m
@@ -182,7 +182,7 @@
             else if ([DiscoveryManager isAddressLAN:inet_addr([hostAddress UTF8String])]) {
                 // Don't send a STUN request if we're connected to a VPN. We'll likely get the VPN
                 // gateway's external address rather than the external address of the LAN.
-                if (![Utils isActiveNetworkVPN]) {
+                if (![Utils isActiveNetworkVPN] && ![NSUserDefaults.standardUserDefaults boolForKey:@"disableSTUNProbe"]) {
                     // This host was discovered over a permissible LAN address, so we can update our
                     // external address for this host.
                     struct in_addr wanAddr;

--- a/Limelight/Network/MDNSManager.m
+++ b/Limelight/Network/MDNSManager.m
@@ -186,7 +186,7 @@ static NSString* NV_SERVICE_TYPE = @"_nvstream._tcp";
             
             // Don't send a STUN request if we're connected to a VPN. We'll likely get the VPN
             // gateway's external address rather than the external address of the LAN.
-            if (![Utils isActiveNetworkVPN]) {
+            if (![Utils isActiveNetworkVPN] && ![NSUserDefaults.standardUserDefaults boolForKey:@"disableSTUNProbe"]) {
                 // Since we discovered this host over IPv4 mDNS, we know we're on the same network
                 // as the PC and we can use our current WAN address as a likely candidate
                 // for our PC's external address.


### PR DESCRIPTION
The Moonlight client pings an external STUN server (stun.moonlight-stream.org) to determine the external IP address of the streaming setup. In a purely local setup, this should not be necessary for functionality and thus becomes a bit of a privacy leak: stun.moonlight-stream.org or anyone along the route can theoretically observe these pings and thus determine patterns in my usage of Moonlight.

I added a hidden preference to disable these pings to `NSUserDefaults`. It’s a boolean called `disableSTUNProbe`. Setting this to true prevents these STUN probes. This could become a user-exposed option in the future, but since it is a bit technical it might require more explanation. So far, this hidden preference is a useful starting point for me.