### PR TITLE
Switch to a more reliable way of updating the build number.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/Moonlight.xcscmblueprint
 Build
 DerivedData
+Limelight/Version.xcconfig

--- a/Limelight/build-number.sh
+++ b/Limelight/build-number.sh
@@ -1,0 +1,4 @@
+cd "$SRCROOT"
+git=`sh /etc/profile; which git`
+bundleVersion=`"$git" rev-list --count HEAD`
+echo "BUILD_NUMBER = $bundleVersion" > "${PROJECT_DIR}/Limelight/Version.xcconfig"

--- a/Limelight/macOS/Supporting Files/Info.plist
+++ b/Limelight/macOS/Supporting Files/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(BUILD_NUMBER)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				/Localized/macOS/Main.storyboard,
+				"build-number.sh",
 				Crypto/CryptoManager.m,
 				Crypto/IdManager.m,
 				Crypto/mkcert.c,
@@ -143,6 +144,7 @@
 				Stream/VideoDecoderRenderer.m,
 				Utility/Logger.m,
 				Utility/Utils.m,
+				Version.xcconfig,
 			);
 			target = 4C7E0A791FECBFFD00684411 /* Moonlight for macOS */;
 		};
@@ -216,7 +218,6 @@
 				4C7E0A761FECBFFD00684411 /* Sources */,
 				4C7E0A771FECBFFD00684411 /* Frameworks */,
 				4C7E0A781FECBFFD00684411 /* Resources */,
-				4C682BD324D1264100A70C44 /* Set Build Number */,
 				A428584B2D50682400E39078 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -299,28 +300,6 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		4C682BD324D1264100A70C44 /* Set Build Number */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Set Build Number";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbundleVersion=`\"$git\" rev-list --all |wc -l`\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $bundleVersion\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		4C7E0A761FECBFFD00684411 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -345,6 +324,8 @@
 /* Begin XCBuildConfiguration section */
 		4C7E0A8B1FECBFFD00684411 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = A40F5A3F2D432ABE006DA227 /* Limelight */;
+			baseConfigurationReferenceRelativePath = Version.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -391,6 +372,8 @@
 		};
 		4C7E0A8C1FECBFFD00684411 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = A40F5A3F2D432ABE006DA227 /* Limelight */;
+			baseConfigurationReferenceRelativePath = Version.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Moonlight.xcodeproj/xcshareddata/xcschemes/Moonlight for macOS.xcscheme
+++ b/Moonlight.xcodeproj/xcshareddata/xcschemes/Moonlight for macOS.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "source $SRCROOT/Limelight/build-number.sh&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "4C7E0A791FECBFFD00684411"
+                     BuildableName = "Moonlight.app"
+                     BlueprintName = "Moonlight for macOS"
+                     ReferencedContainer = "container:Moonlight.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4C7E0A791FECBFFD00684411"
+               BuildableName = "Moonlight.app"
+               BlueprintName = "Moonlight for macOS"
+               ReferencedContainer = "container:Moonlight.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C7E0A791FECBFFD00684411"
+            BuildableName = "Moonlight.app"
+            BlueprintName = "Moonlight for macOS"
+            ReferencedContainer = "container:Moonlight.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C7E0A791FECBFFD00684411"
+            BuildableName = "Moonlight.app"
+            BlueprintName = "Moonlight for macOS"
+            ReferencedContainer = "container:Moonlight.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
- The previous way, updating the Info.plist directly in the output bundle using PListBuddy, would sometime fail (race condition?). This way, the git command to count the commits is run on each build, and a .xcconfig is used to hold the value.
- The only downside of this is that this step needs to be run before the build (so that the new value of the .xcconfig file is picked up). The only way that I could see to do that was by adding a Pre-build step to the Scheme. This means that the scheme needs to be Shared, and checked in, and Xcode seems to randomly change the scheme files. (Someone (I can't find who), suggested that always selecting the same target and platform (e.g Any Mac), before committing to git, helps with this.