### PR TITLE
Move "Remove Host" menu action to bottom of context menu

### DIFF
--- a/Limelight/macOS/HostCell.xib
+++ b/Limelight/macOS/HostCell.xib
@@ -127,16 +127,17 @@
                         <action selector="wakeMenuItemClicked:" target="-1" id="QRb-YP-iMw"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Remove Host" image="trash" catalog="system" identifier="removeHostMenuItem" id="xzr-nr-OxJ">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="removeHostMenuItemClicked:" target="-1" id="tfu-ld-UU0"/>
-                    </connections>
-                </menuItem>
                 <menuItem title="Show Hidden Apps" image="eye" catalog="system" identifier="showHiddenAppsMenuItem" id="RwF-WV-9CR">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="showHiddenAppsMenuItemClicked:" target="-1" id="s7m-Rv-gUh"/>
+                    </connections>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="OSO-o5-BuN"/>
+                <menuItem title="Remove Host" image="trash" catalog="system" identifier="removeHostMenuItem" id="xzr-nr-OxJ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="removeHostMenuItemClicked:" target="-1" id="tfu-ld-UU0"/>
                     </connections>
                 </menuItem>
             </items>


### PR DESCRIPTION
This relocates the “Remove host” context menu item to the bottom of the menu and adds a separator before it. Moving the destructive menu action further away from other actions reduces the likelihood that someone will accidentally take a destructive action.

This change is inspired by me accidentally clicking “remove host” instead of “wake PC” just now while trying to connect, and then having to go downstairs and plug a keyboard+monitor in to the PC to re-pair it >.<